### PR TITLE
update output to show the latest version of the tools

### DIFF
--- a/mac_linux/update_k8s_tools.sh
+++ b/mac_linux/update_k8s_tools.sh
@@ -33,10 +33,11 @@ download_kind_cli() {
     fi
 
     if [[ -z "${KIND_BINARY}" || ! -f "${KIND_BINARY}" ]]; then
-        echo -e "\n\t--- Downloading KIND cli ...\n"
 
         # curl -sL https://api.github.com/repos/kubernetes-sigs/kind/releases | jq -r '.[0].assets[] | .browser_download_url'
         latest_version=$(curl -sL https://api.github.com/repos/kubernetes-sigs/kind/releases | jq -r '.[0].name')
+        echo -e "\n\t--- Downloading KIND cli ${latest_version} ...\n"
+
         curl -Lo ${KIND_BINARY} https://github.com/kubernetes-sigs/kind/releases/download/${latest_version}/kind-${TYPE_OS}-${TYPE_PLATFORM}
         chmod +x ${KIND_BINARY}
 
@@ -53,8 +54,9 @@ download_kubectl() {
     fi
 
     if [[ -z "${KUBECTL_BINARY}" || ! -f "${KUBECTL_BINARY}" ]]; then
-        echo -e "\n\t--- Downloading KUBECTL cli ...\n"
-        curl -Lo ${KUBECTL_BINARY} "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/${TYPE_OS}/${TYPE_PLATFORM}/kubectl"
+        latest_version=$(curl -L -s https://dl.k8s.io/release/stable.txt)
+        echo -e "\n\t--- Downloading KUBECTL cli ${latest_version} ...\n"
+        curl -Lo ${KUBECTL_BINARY} "https://dl.k8s.io/release/${latest_version}/bin/${TYPE_OS}/${TYPE_PLATFORM}/kubectl"
         chmod +x ${KUBECTL_BINARY}
 
     else
@@ -70,11 +72,10 @@ download_helm() {
     fi
 
     if [[ -z "${HELM_BINARY}" || ! -f "${HELM_BINARY}" ]]; then
-        echo -e "\n\t--- Downloading HELM cli ...\n"
-
         latest_version=$(curl -sL https://api.github.com/repos/helm/helm/releases | jq -r '.[0].name' | tr -d "Helm ")
-        curl -Lo ${CURRENT_DIR}/helm.tar.gz https://get.helm.sh/helm-v${latest_version}-${TYPE_OS}-${TYPE_PLATFORM}.tar.gz
+        echo -e "\n\t--- Downloading HELM cli ${latest_version} ...\n"
 
+        curl -Lo ${CURRENT_DIR}/helm.tar.gz https://get.helm.sh/helm-v${latest_version}-${TYPE_OS}-${TYPE_PLATFORM}.tar.gz
         tar -zxvf helm.tar.gz
         mv ${CURRENT_DIR}/${TYPE_OS}-${TYPE_PLATFORM}/helm ${CURRENT_DIR}/
         chmod +x ${HELM_BINARY}
@@ -93,9 +94,8 @@ download_istioctl() {
     fi
 
     if [[ -z "${ISTIOCTL_BINARY}" || ! -f "${ISTIOCTL_BINARY}" ]]; then
-        echo -e "\n\t--- Downloading ISTIO cli ...\n"
-
         latest_version=$(curl -sL https://api.github.com/repos/istio/istio/releases/latest | jq -r '.name' | tr -d "Istio ")
+        echo -e "\n\t--- Downloading ISTIO cli ${latest_version} ...\n"
 
         curl -L https://istio.io/downloadIstio | ISTIO_VERSION=${latest_version} sh -
         mv ./istio-${latest_version}/bin/istioctl ./


### PR DESCRIPTION
Sample run:
```
$ ./update_k8s_tools.sh 

	===== Downloading the latest bits of K8s tools if needed ...


	--- Downloading KIND cli v0.24.0 ...

  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100 9697k  100 9697k    0     0  3859k      0  0:00:02  0:00:02 --:--:-- 6032k

	--- Downloading KUBECTL cli v1.31.1 ...

  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   138  100   138    0     0    878      0 --:--:-- --:--:-- --:--:--   878
100 53.7M  100 53.7M    0     0  5108k      0  0:00:10  0:00:10 --:--:-- 6461k

	--- Downloading HELM cli 3.16.1 ...

  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 16.5M  100 16.5M    0     0  2427k      0  0:00:06  0:00:06 --:--:-- 2531k
linux-amd64/
linux-amd64/LICENSE
linux-amd64/helm
linux-amd64/README.md

	--- Downloading ISTIO cli 1.23.2 ...

  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   102  100   102    0     0    142      0 --:--:-- --:--:-- --:--:--   142
100  4899  100  4899    0     0   4836      0  0:00:01  0:00:01 --:--:--  4836

Downloading istio-1.23.2 from https://github.com/istio/istio/releases/download/1.23.2/istio-1.23.2-linux-amd64.tar.gz ...

Istio 1.23.2 Download Complete!

Istio has been successfully downloaded into the istio-1.23.2 folder on your system.

Next Steps:
See https://istio.io/latest/docs/setup/install/ to add Istio to your Kubernetes cluster.

To configure the istioctl client tool for your workstation,
add the /home/test/coed/github/public-shared/mac_linux/istio-1.23.2/bin directory to your environment path variable with:
	 export PATH="$PATH:/home/test/coed/github/public-shared/mac_linux/istio-1.23.2/bin"

Begin the Istio pre-installation check by running:
	 istioctl x precheck 

Need more information? Visit https://istio.io/latest/docs/setup/install/ 
```